### PR TITLE
descriptors: add types.descriptors.partial for parsing potentially incomplete data

### DIFF
--- a/usb_protocol/types/descriptors/partial/__init__.py
+++ b/usb_protocol/types/descriptors/partial/__init__.py
@@ -1,0 +1,1 @@
+from .standard import *

--- a/usb_protocol/types/descriptors/partial/standard.py
+++ b/usb_protocol/types/descriptors/partial/standard.py
@@ -1,0 +1,11 @@
+""" Convenience aliases for versions of descriptor structs that support parsing incomplete binary data. """
+
+from .. import standard
+
+DeviceDescriptor          = standard.DeviceDescriptor.Partial
+ConfigurationDescriptor   = standard.ConfigurationDescriptor.Partial
+StringDescriptor          = standard.StringDescriptor.Partial
+StringLanguageDescriptor  = standard.StringLanguageDescriptor.Partial
+InterfaceDescriptor       = standard.InterfaceDescriptor.Partial
+EndpointDescriptor        = standard.EndpointDescriptor.Partial
+DeviceQualifierDescriptor = standard.DeviceQualifierDescriptor.Partial

--- a/usb_protocol/types/descriptors/standard.py
+++ b/usb_protocol/types/descriptors/standard.py
@@ -1,7 +1,12 @@
 #
 # This file is part of usb-protocol.
 #
-""" Structures describing standard USB descriptors. """
+"""
+Structures describing standard USB descriptors. Versions that support parsing incomplete binary data
+are available as `DescriptorType`.Partial, e.g. `DeviceDescriptor.Partial`, and are collectively available
+in the `usb_protocol.types.descriptors.partial.standard` module (which, like the structs in this module,
+can also be imported without `.standard`).
+"""
 
 import unittest
 from enum import IntEnum


### PR DESCRIPTION
This re-allows parsing partial descriptors, which had previously been allowed until 7672fb522182dabe6afa71a1ee2653a792507359.

With this, whenever a descriptor format is created with `DescriptorFormat()`, it will automatically create a version of that format that supports parsing incomplete data as the attribute `.Partial`. So `DeviceDescriptor.Partial` is a copy of the device descriptor `DescriptorFormat` that supports partial parsing. These partial versions are re-exported in the `types.descriptors.partial` module.