### PR TITLE
Minimal change to allow support of HID descriptors

### DIFF
--- a/usb_protocol/emitters/descriptors/standard.py
+++ b/usb_protocol/emitters/descriptors/standard.py
@@ -208,12 +208,14 @@ class DeviceDescriptorCollection:
         return index
 
 
-    def add_descriptor(self, descriptor, index=0):
+    def add_descriptor(self, descriptor, index=0, descriptor_type=None):
         """ Adds a descriptor to our collection.
 
         Parameters:
-            descriptor -- The descriptor to be added.
-            index      -- The index of the relevant descriptor. Defaults to 0.
+            descriptor      -- The descriptor to be added.
+            index           -- The index of the relevant descriptor. Defaults to 0.
+            descriptor_type -- The type of the descriptor to be added. If `None`,
+                               this is automatically derived from the descriptor contents.
         """
 
         # If this is an emitter rather than a descriptor itself, convert it.
@@ -221,7 +223,8 @@ class DeviceDescriptorCollection:
             descriptor = descriptor.emit()
 
         # Figure out the identifier (type + index) for this descriptor...
-        descriptor_type = descriptor[1]
+        if (descriptor_type is None):
+            descriptor_type = descriptor[1]
         identifier = descriptor_type, index
 
         # ... and store it.
@@ -566,5 +569,3 @@ class EmitterTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-


### PR DESCRIPTION
This is a minimum, conservative, change set extracted from https://github.com/usb-tools/python-usb-protocol/pull/6 to allow the addition (as binary blobs) of HID Report Descriptors. These do not contain their type in the first octet so the existing mechanisms don't work.  With this PR a HID Report Descriptor can be attached directly to a DeviceDescriptorCollection provided it's HID Descriptor has been attached to an interface. A typical configuration would be;

```
interface.add_subordinate_descriptor(b"\x09\x21\x11\x01\x00\x01\x22\x21\x00")
descriptors.add_descriptor(b"\x06\x00\xFF\x09\x01\xA1\x01\x15\x00\x26\xFF\x00\x75\x08\x95\x40\x09\x01\x81"
    b"\x02\x95\x40\x09\x01\x91\x02\x95\x01\x09\x01\xB1\x02\xC0",descriptor_type=0x22)
```
I don't think this is a complete solution to support HIDs, but it does allow them to be used today while the issues in the above PR are resolved.